### PR TITLE
fix: updated action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: 'Setup Canarycage'
 description: 'Download and add cage to the PATH'
 author: 'LoiLo'
 inputs:
+  github-token:
+    description: "Use secrets.GITHUB_TOKEN."
+    required: true
   cage-version:
     description: "Canarycage version. If no version specified, the latest version will be used automatically."
     required: false


### PR DESCRIPTION
The warning was caused by not updating action.yml
![image](https://user-images.githubusercontent.com/17838713/211486714-c0d6f828-4905-44cf-aac5-b8c6360cd898.png)